### PR TITLE
serve this file from root of domain for google oauth domain verification

### DIFF
--- a/public/google4109145461dfc4bf.html
+++ b/public/google4109145461dfc4bf.html
@@ -1,0 +1,1 @@
+google-site-verification: google4109145461dfc4bf.html


### PR DESCRIPTION
Google oauth requires a verification file be served from the root of the domain.